### PR TITLE
feat: add Docker + npm root scan, switch to weekly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,12 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
   reviewers:
   - alexanderbez
@@ -17,9 +17,19 @@ updates:
   - automerge
   - dependencies
 - package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+- package-ecosystem: npm
   directory: "/docs"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
   reviewers:
   - fadeev
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Add Docker ecosystem scan
- Add npm scan for root directory (in addition to /docs)
- Switch all schedules from daily to weekly
- Add `open-pull-requests-limit: 10` to all blocks