### PR TITLE
ci: add incremental secret scanning INF-163

### DIFF
--- a/.github/workflows/tn-incremental-secret-scan.yml
+++ b/.github/workflows/tn-incremental-secret-scan.yml
@@ -1,0 +1,17 @@
+name: TN Incremental Secret Scan
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan:
+    uses: treasurenetprotocol/reusable-workflows/.github/workflows/reusable-secrets-scanning.yml@d82d3ef57336183b47a09c40717ea0560e4e50f6
+    with:
+      scan_mode: ${{ github.event_name == 'pull_request' && 'pr' || 'push' }}
+      fetch_depth: 0
+      fail_threshold: high
+      config_ref: d82d3ef57336183b47a09c40717ea0560e4e50f6


### PR DESCRIPTION
## Summary
- add the organization-standard incremental secret scan
- scan every pull request and every branch push
- block high/critical new findings using the immutable INF-162 workflow and rules
- keep full-history scanning out of INF-163

## Security behavior
- GitHub native push protection is enabled separately for supported provider secrets
- the Action adds TN-specific detection and sanitized evidence
- deleting a committed real secret is not remediation; rotate or abandon it

Linear: https://linear.app/treasurenet/issue/INF-163/roll-out-incremental-secret-scanning-to-priority-tn-repositories